### PR TITLE
Fix selection sort array length bug

### DIFF
--- a/agorithm/Untitled-1.cpp
+++ b/agorithm/Untitled-1.cpp
@@ -21,7 +21,7 @@ void Sap_xep_chon( int a[], int n){
 
 int main(){
     int arr[] = {64, 25, 12, 22, 11};
-    int n = sizeof(arr);
+    int n = sizeof(arr) / sizeof(arr[0]);
     // in mang chua duoc sap xep
     printf("Original array: ");
     for (int i=0; i<= n-1; i++){


### PR DESCRIPTION
## Summary
- correct array length calculation in `agorithm/Untitled-1.cpp`

## Testing
- `gcc agorithm/Untitled-1.cpp -o select_sort && ./select_sort`

------
https://chatgpt.com/codex/tasks/task_e_6889a46a522c833182c3f987923a4332